### PR TITLE
Fix machine translation

### DIFF
--- a/aspnetcore/getting-started/index.md
+++ b/aspnetcore/getting-started/index.md
@@ -39,7 +39,7 @@ W tym dokumencie przedstawiono kroki umożliwiające utworzenie i uruchomienie a
 
   ![Okno dialogowe ostrzeżenia o zabezpieczeniach](_static/cert.png)
 
-  Wybierz **tak** Jeśli zgadzasz się ufać certyfikatowi deweloperskiemu.
+  Wybierz **Tak**, jeśli zgadzasz się ufać certyfikatowi programistycznemu.
 
 # <a name="macostabmacos"></a>[macOS](#tab/macos)
 
@@ -54,11 +54,11 @@ W tym dokumencie przedstawiono kroki umożliwiające utworzenie i uruchomienie a
   
   Hasło: *
 
-  Wprowadź hasło, jeśli zgadzasz się ufać certyfikatowi deweloperskiemu.
+  Wprowadź hasło, jeśli zgadzasz się ufać certyfikatowi programistycznemu.
 
 # <a name="linuxtablinux"></a>[Linux](#tab/linux)
 
-  Sprawd w dokumentacji dla Twojej dystrybucji systemu Linux informacje na temat dodania certyfikatu deweloperskiego do zaufanych certyfikatów protokołu HTTPS.
+  Sprawdź w dokumentacji dla Twojej dystrybucji systemu Linux informacje na temat dodania certyfikatu deweloperskiego do zaufanych certyfikatów protokołu HTTPS.
    
 ---
 
@@ -69,7 +69,7 @@ W tym dokumencie przedstawiono kroki umożliwiające utworzenie i uruchomienie a
    dotnet run
    ```
 
-5. Przejdź do [http://localhost:5001](http://localhost:5001).  Kliknij przycisk **Akceptuj** zaakceptować zasady ochrony prywatności i plików cookie. Ta aplikacja nie zachowuje informacji osobistych.
+5. Przejdź do [http://localhost:5001](http://localhost:5001). Kliknij przycisk **Akceptuj**, aby zaakceptować zasady ochrony prywatności i plików cookie. Ta aplikacja nie zachowuje informacji osobistych.
 
 6. Otwórz *Pages/About.cshtml* i zmodyfikuj stronę w wyróżnionym miejscu w następującym przykładzie:
 
@@ -106,7 +106,7 @@ W tym dokumencie przedstawiono kroki umożliwiające utworzenie i uruchomienie a
 
    [!code-cshtml[](sample/getting-started/about.cshtml?highlight=9&range=1-9)]
 
-6. Przejdź do [http://localhost:5000/About](http://localhost:5000/About) a następnie zweryfikuj zmiany.
+6. Przejdź do [http://localhost:5000/About](http://localhost:5000/About), a następnie zweryfikuj zmiany.
 
 [!INCLUDE [next steps](~/includes/getting-started/next-steps.md)]
 
@@ -151,7 +151,7 @@ W tym dokumencie przedstawiono kroki umożliwiające utworzenie i uruchomienie a
    dotnet run
    ```
 
-   Polecenie [dotnet run](/dotnet/core/tools/dotnet-run) zbuduje najpierw aplikację, jeśli jest to konieczne.
+   Polecenie [dotnet run](/dotnet/core/tools/dotnet-run) skompiluje najpierw aplikację, jeśli jest to konieczne.
 
 7. Przejdź do `http://localhost:5000`.
 

--- a/aspnetcore/getting-started/index.md
+++ b/aspnetcore/getting-started/index.md
@@ -39,7 +39,7 @@ W tym dokumencie przedstawiono kroki umożliwiające utworzenie i uruchomienie a
 
   ![Okno dialogowe ostrzeżenia o zabezpieczeniach](_static/cert.png)
 
-  Wybierz **tak** Jeśli zgadzasz się ufać certyfikatowi rozwoju.
+  Wybierz **tak** Jeśli zgadzasz się ufać certyfikatowi deweloperskiemu.
 
 # <a name="macostabmacos"></a>[macOS](#tab/macos)
 
@@ -54,11 +54,11 @@ W tym dokumencie przedstawiono kroki umożliwiające utworzenie i uruchomienie a
   
   Hasło: *
 
-  Wprowadź hasło, jeśli zgadzasz się ufać certyfikatowi rozwoju.
+  Wprowadź hasło, jeśli zgadzasz się ufać certyfikatowi deweloperskiemu.
 
 # <a name="linuxtablinux"></a>[Linux](#tab/linux)
 
-  W dokumentacji dla Twojej dystrybucji systemu Linux na temat zaufania certyfikatu deweloperskiego protokołu HTTPS.
+  Sprawd w dokumentacji dla Twojej dystrybucji systemu Linux informacje na temat dodania certyfikatu deweloperskiego do zaufanych certyfikatów protokołu HTTPS.
    
 ---
 
@@ -69,13 +69,13 @@ W tym dokumencie przedstawiono kroki umożliwiające utworzenie i uruchomienie a
    dotnet run
    ```
 
-5. Przejdź do [ http://localhost:5001 ](http://localhost:5001).  Kliknij przycisk **Akceptuj** zaakceptować zasady ochrony prywatności i plików cookie. Ta aplikacja nie zachowuje informacji osobistych.
+5. Przejdź do [http://localhost:5001](http://localhost:5001).  Kliknij przycisk **Akceptuj** zaakceptować zasady ochrony prywatności i plików cookie. Ta aplikacja nie zachowuje informacji osobistych.
 
-6. Otwórz *Pages/About.cshtml* i modyfikować strony z następujący wyróżniony kod znaczników:
+6. Otwórz *Pages/About.cshtml* i zmodyfikuj stronę w wyróżnionym miejscu w następującym przykładzie:
 
    [!code-cshtml[](sample/getting-started/about.cshtml?highlight=9)]
 
-7. Przejdź do [ http://localhost:5001/About ](http://localhost:5001/About) i Sprawdź zmiany są wyświetlane.
+7. Przejdź do [http://localhost:5001/About](http://localhost:5001/About) i sprawdź, czy zmiany są wyświetlane.
 
 [!INCLUDE [next steps](~/includes/getting-started/next-steps.md)]
 
@@ -100,13 +100,13 @@ W tym dokumencie przedstawiono kroki umożliwiające utworzenie i uruchomienie a
    dotnet run
    ```
 
-4. Przejdź do [ http://localhost:5000 ](http://localhost:5000).
+4. Przejdź do [http://localhost:5000](http://localhost:5000).
 
-5. Otwórz *Pages/About.cshtml*i zmodyfikuj stronę, aby wyświetlić komunikat „Hello, world! Czas na serwerze jest @DateTime.Now":
+5. Otwórz *Pages/About.cshtml* i zmodyfikuj stronę, aby wyświetlić komunikat „Hello, world! Czas na serwerze jest @DateTime.Now":
 
    [!code-cshtml[](sample/getting-started/about.cshtml?highlight=9&range=1-9)]
 
-6. Przejdź do [ http://localhost:5000/About ](http://localhost:5000/About) a następnie zweryfikować zmiany.
+6. Przejdź do [http://localhost:5000/About](http://localhost:5000/About) a następnie zweryfikuj zmiany.
 
 [!INCLUDE [next steps](~/includes/getting-started/next-steps.md)]
 
@@ -125,7 +125,7 @@ W tym dokumencie przedstawiono kroki umożliwiające utworzenie i uruchomienie a
    cd aspnetcoreapp
    ```
 
-3. Jeśli na komputerze zainstalowano nowszej wersji zestawu SDK, utworzyć *global.json* plik, aby zaznaczyć 1.0.4 zestawu SDK.
+3. Jeśli na komputerze zainstalowano nowszą wersję zestawu SDK, utwórz plik *global.json*, aby zaznaczyć wykorzystanie SDK w wersji 1.0.4.
 
    ```json
    {
@@ -151,7 +151,7 @@ W tym dokumencie przedstawiono kroki umożliwiające utworzenie i uruchomienie a
    dotnet run
    ```
 
-   [Dotnet, uruchom](/dotnet/core/tools/dotnet-run) polecenie tworzy najpierw aplikacji, jeśli to konieczne.
+   Polecenie [dotnet run](/dotnet/core/tools/dotnet-run) zbuduje najpierw aplikację, jeśli jest to konieczne.
 
 7. Przejdź do `http://localhost:5000`.
 

--- a/aspnetcore/release-notes/aspnetcore-2.1.md
+++ b/aspnetcore/release-notes/aspnetcore-2.1.md
@@ -33,60 +33,60 @@ Aby uzyskać więcej informacji, zobacz [biblioteki SignalR platformy ASP.NET Co
 
 ## <a name="razor-class-libraries"></a>Biblioteki klas Razor
 
-ASP.NET Core 2.1 ułatwia tworzenie i dołączanie interfejsu użytkownika opartego na Razor w bibliotece i udostępnianie go w wielu projektach. Nowe Razor SDK umożliwia kompilowanie plików Razor do bibliotek klas, które mogą być umieszczone w pakietach NuGet. Widoki stron w bibliotekach są automatycznie wykrywane i mogą być nadpisane w aplikacji. Dzięki integracji kompilacji Razor do kompilacji:
+ASP.NET Core 2.1 ułatwia tworzenie i dołączanie interfejsu użytkownika opartego na składni Razor w bibliotece i udostępnianie go w wielu projektach. Nowy zestaw SDK Razor umożliwia kompilowanie plików Razor do projektów bibliotek klas, które mogą być umieszczone w pakietach NuGet. Widoki i strony w bibliotekach są automatycznie wykrywane i mogą być nadpisane w aplikacji. Dzięki integracji kompilacji Razor w kompilacji:
 
 * Czas uruchamiania aplikacji jest znacznie krótszy.
-* Szybkie aktualizacje widoków Razor i stron w czasie wykonywania są nadal dostępne jako część przepływu pracy iteracyjne projektowanie.
+* Szybkie aktualizacje widoków i stron Razor w czasie wykonywania są nadal dostępne jako część przepływu pracy iteracyjnego programowania.
 
 Aby uzyskać więcej informacji, zobacz [tworzenia interfejsu użytkownika do wielokrotnego użytku, używając projektu biblioteki klas Razor](xref:razor-pages/ui-class).
 
 ## <a name="identity-ui-library--scaffolding"></a>Biblioteka interfejsów użytkownika tożsamości i tworzenia szkieletów
 
-Platforma ASP.NET Core 2.1 udostępnia mechanizm [tożsamości platformy ASP.NET Core](xref:security/authentication/identity) jako [bibliotekę klas Razor](xref:razor-pages/ui-class). Aplikacje, które używają mechanizmu tożsamości mogą zastosować nowy generator szkieletu tożsamości, aby wybiórczo wykorzystać kod źródłowy, znajdujący się w bibliotece klas Razor tożsamości (RCL). Można wygenerować kod źródłowy, aby można było zmodyfikować kod i zmienić zachowanie. Na przykład można nakazać Generatorowi szkieletu wygenerowanie kodu używanego podczas rejestracji. Wygenerowany kod ma pierwszeństwo przed ten sam kod w RCL tożsamości.
+Platforma ASP.NET Core 2.1 udostępnia mechanizm [tożsamości platformy ASP.NET Core](xref:security/authentication/identity) jako [bibliotekę klas Razor](xref:razor-pages/ui-class). Aplikacje, które używają mechanizmu tożsamości, mogą zastosować nowy generator szkieletu tożsamości, aby wybiórczo dodawać kod źródłowy, znajdujący się w bibliotece klas Razor tożsamości (RCL). Przydatne może być wygenerowanie kodu źródłowego, aby można było zmodyfikować kod i zmienić zachowanie. Na przykład można nakazać Generatorowi szkieletu wygenerowanie kodu używanego podczas rejestracji. Wygenerowany kod ma pierwszeństwo przed tym samym kodem w bibliotece RCL tożsamości.
 
-Aplikacje, które **nie** obejmują uwierzytelniania mogą zastosować Generator szkieletu tożsamości, aby dodać pakiet RCL tożsamości. Masz możliwość wyboru kodu do wygenerowania.
+Aplikacje, które **nie** obejmują uwierzytelniania, mogą zastosować Generator szkieletu tożsamości, aby dodać pakiet RCL tożsamości. Masz możliwość wyboru kodu tożsamości do wygenerowania.
 
 Aby uzyskać więcej informacji, zobacz [szkieletu tożsamość w projektach programu ASP.NET Core](xref:security/authentication/scaffold-identity).
 
 ## <a name="https"></a>HTTPS
 
-Aby lepiej skoncentrować się na zabezpieczeniach i prywatności ważne jest włączenie protokołu HTTPS dla aplikacji sieci Web. Wymuszanie protokołu HTTPS staje się coraz bardziej rygorystyczne w sieci Web. Lokacje, które nie używają protokołu HTTPS, są uważane za niebezpieczne. Przeglądarki (Chromium, Mozilla) coraz częściej wymuszają, aby funkcje sieci Web powinny być używane w bezpiecznym kontekście. [RODO](xref:security/gdpr) wymaga użycia protokołu HTTPS, aby chronić prywatność użytkowników. Użycie protokołu HTTPS w środowisku produkcyjnym jest krytyczne, natomiast w środowisku rozwojowym może zapobiec problemom we wdrożeniu (na przykład niezabezpieczone łącza). Platforma ASP.NET Core 2.1 zawiera szereg ulepszeń, które ułatwiają wykorzystanie protokołu HTTPS podczas tworzenia i konfigurowania protokołu HTTPS w środowisku produkcyjnym. Aby uzyskać więcej informacji, zobacz [Wymuszanie protokołu HTTPS](xref:security/enforcing-ssl).
+Aby lepiej skoncentrować się na zabezpieczeniach i prywatności, ważne jest włączenie protokołu HTTPS dla aplikacji sieci Web. Wymuszanie protokołu HTTPS staje się coraz bardziej rygorystyczne w sieci Web. Lokacje, które nie używają protokołu HTTPS, są uważane za niebezpieczne. Przeglądarki (Chromium, Mozilla) coraz częściej wymuszają, aby funkcje sieci Web były używane w bezpiecznym kontekście. [RODO](xref:security/gdpr) wymaga użycia protokołu HTTPS, aby chronić prywatność użytkowników. Użycie protokołu HTTPS w środowisku produkcyjnym jest krytyczne, natomiast w środowisku programistycznym może zapobiec problemom we wdrożeniu (takim jak niezabezpieczone linki). Platforma ASP.NET Core 2.1 zawiera szereg ulepszeń, które ułatwiają wykorzystanie protokołu HTTPS podczas programowania i konfigurowanie protokołu HTTPS w środowisku produkcyjnym. Aby uzyskać więcej informacji, zobacz [Wymuszanie protokołu HTTPS](xref:security/enforcing-ssl).
 
 ### <a name="on-by-default"></a>Włączony domyślnie
 
-W celu ułatwienia tworzenia bezpiecznej witryny sieci Web, HTTPS jest teraz włączony domyślnie. Począwszy od 2.1 Kestrel nasłuchuje na `https://localhost:5001` kiedy certyfikat deweloperski jest obecny. Utworzenie certyfikatu deweloperskiego:
+W celu ułatwienia tworzenia bezpiecznej witryny sieci Web protokół HTTPS jest teraz włączony domyślnie. Począwszy od wersji 2.1 serwer Kestrel nasłuchuje na porcie `https://localhost:5001`, kiedy lokalny certyfikat programistyczny jest obecny. Certyfikat programistyczny jest tworzony:
 
 * Jako część zestawu .NET Core SDK pierwszego uruchomienia komputera, gdy używasz zestawu SDK po raz pierwszy.
 * Ręcznie przy użyciu nowego narzędzia `dev-certs`.
+	
+Uruchom polecenie `dotnet dev-certs https --trust`, aby zaufać certyfikatowi.
 
-Uruchom `dotnet dev-certs https --trust`, aby zaufać certyfikatowi.
+### <a name="https-redirection-and-enforcement"></a>Przekierowania i wymuszenia protokołu HTTPS
 
-### <a name="https-redirection-and-enforcement"></a>Przekierowania protokołu HTTPS i wymuszenia
+Aplikacje internetowe zazwyczaj wymagają nasłuchiwania protokołów HTTP i HTTPS, ale następnie przekierowują cały ruchu HTTP na HTTPS. W wersji 2.1 zostało wprowadzone wyspecjalizowane oprogramowanie pośredniczące przekierowania protokołu HTTPS inteligentnie przekierowujące na podstawie obecności konfiguracji lub powiązanych portów serwera.
 
-Aplikacje internetowe zazwyczaj wymagają nasłuchiwania protokołów HTTP i HTTPS, ale następnie przekierowania całego ruchu HTTP na HTTPS. W wersji 2.1 zostało wprowadzone wyspecjalizowane oprogramowanie pośredniczące przekierowania protokołu HTTPS, inteligentnie przekierowujące na podstawie obecności konfiguracji lub powiązanych portów.
-
-Korzystanie z protokołu HTTPS można dodatkowo wymuszane, za pomocą [interfejsów HTTP Strict Transport Security (HSTS)](xref:security/enforcing-ssl#http-strict-transport-security-protocol-hsts). HSTS powoduje, że przeglądarka zawsze uzyskuje dostęp do witryny za pośrednictwem protokołu HTTPS. Platforma ASP.NET Core 2.1 dodaje oprogramowanie pośredniczące HSTS, który obsługuje opcje dla maksymalnego wieku, poddomen, i listy wstępnego ładowania HSTS.
+Korzystanie z protokołu HTTPS może być dodatkowo wymuszane za pomocą [protokołu HTTP Strict Transport Security (HSTS)](xref:security/enforcing-ssl#http-strict-transport-security-protocol-hsts). HSTS powoduje, że przeglądarka zawsze uzyskuje dostęp do witryny za pośrednictwem protokołu HTTPS. Platforma ASP.NET Core 2.1 dodaje oprogramowanie pośredniczące HSTS, które obsługuje opcje dla maksymalnego wieku, poddomen i listy wstępnego ładowania HSTS.
 
 ### <a name="configuration-for-production"></a>Konfiguracja dla trybu produkcyjnego
 
 W środowisku produkcyjnym należy jawnie skonfigurować protokół HTTPS. W wersji 2.1 został dodany domyślny schemat konfiguracji dotyczący konfigurowania protokołu HTTPS dla serwera Kestrel. Aplikacje można skonfigurować do użycia:
 
-* Wielu punktów końcowych, w tym adresów URL. Aby uzyskać więcej informacji, zobacz [implementacji serwera sieci web Kestrel: Konfiguracja punktu końcowego](xref:fundamentals/servers/kestrel#endpoint-configuration).
+* Wielu punktów końcowych, w tym adresów URL. Aby uzyskać więcej informacji, zobacz [Implementacja serwera sieci web Kestrel: Konfiguracja punktu końcowego](xref:fundamentals/servers/kestrel#endpoint-configuration).
 * Certyfikatu używanego do obsługi protokołu HTTPS z pliku na dysku lub z magazynu certyfikatów.
 
 ## <a name="gdpr"></a>RODO
 
-Platforma ASP.NET Core udostępnia interfejsy API i szablony, które ułatwiają korzystanie z niektórych wymagań [Ogólne rozporządzenie o ochronie danych (GDPR, RODO)](https://www.eugdpr.org/). Aby uzyskać więcej informacji, zobacz [RODO w programie ASP.NET Core](xref:security/gdpr). A w [przykładowej aplikacji](https://github.com/aspnet/Docs/tree/live/aspnetcore/security/gdpr/sample) pokazano, jak i umożliwia testowanie, większość punktów rozszerzenia RODO i interfejsów API, które dodano w szablonach ASP.NET Core 2.1.
+Platforma ASP.NET Core udostępnia interfejsy API i szablony, które ułatwiają spełnienie niektórych wymagań [Ogólnego rozporządzenia o ochronie danych (RODO)](https://www.eugdpr.org/). Aby uzyskać więcej informacji, zobacz [Obsługa RODO w programie ASP.NET Core](xref:security/gdpr). W [przykładowej aplikacji](https://github.com/aspnet/Docs/tree/live/aspnetcore/security/gdpr/sample) pokazano sposób użycia umożliwiono przetestowanie większości punktów rozszerzenia i interfejsów API związanych z RODO, które dodano w szablonach ASP.NET Core 2.1.
 
 ## <a name="integration-tests"></a>Testy integracyjne
 
-Został wprowadzony nowy pakiet upraszczający tworzenie i wykonywanie testów. [Microsoft.AspNetCore.Mvc.Testing](https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc.Testing/) obsługuje następujące zadania:
+Został wprowadzony nowy pakiet upraszczający tworzenie i wykonywanie testów. Pakiet [Microsoft.AspNetCore.Mvc.Testing](https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc.Testing/) obsługuje następujące zadania:
 
 * Kopiuje plik zależności (*\*.deps*) z przetestowanej aplikacji w projekcie testowym *bin* folderu.
-* Ustawia zawartość głównego katalogu głównego projektu przetestowanej aplikacji tak, aby pliki statyczne i stron/widoki są dostępne, gdy testy są wykonywane.
-* Udostępnia klasę [WebApplicationFactory](/dotnet/api/microsoft.aspnetcore.mvc.testing.webapplicationfactory-1), aby usprawnić uruchamianie przetestowanej aplikacji za pomocą [elementu TestServer](/dotnet/api/microsoft.aspnetcore.testhost.testserver).
+* Ustawia katalog główny zawartości na katalog główny projektu testowanej aplikacji, aby można było znaleźć pliki statyczne i strony/widoki podczas wykonywania testów.
+* Udostępnia klasę [WebApplicationFactory](/dotnet/api/microsoft.aspnetcore.mvc.testing.webapplicationfactory-1), aby usprawnić uruchamianie testowanej aplikacji za pomocą [elementu TestServer](/dotnet/api/microsoft.aspnetcore.testhost.testserver).
 
-Następujący test używa [xUnit](https://xunit.github.io/) do sprawdzenia, czy strona indeksu ładuje się z pomyślnym kodem statusu i poprawny nagłówkiem Content-Type:
+Następujący test używa narzędzia [xUnit](https://xunit.github.io/) do sprawdzenia, czy strona indeksu ładuje się z pomyślnym kodem statusu i poprawnym nagłówkiem Content-Type:
 
 ```csharp
 public class BasicTests
@@ -117,13 +117,13 @@ Aby uzyskać więcej informacji, zobacz [testy integracji](xref:test/integration
 
 ## <a name="apicontroller-actionresultt"></a>[ApiController], ActionResult\<T>
 
-Platforma ASP.NET Core 2.1 dodaje nowe konwencje programowania, które ułatwiają tworzenie czystych i bardziej opisowych interfejsów API sieci Web. Dodano nowy typ `ActionResult<T>`, aby zwracać albo typ odpowiedzi albo inny wynik akcji (podobnie jak IActionResult), ale nadal wskazując typ odpowiedzi. Atrybut `[ApiController]` został również dodany jako sposób korzystania z konwencji i zachowań specyficznych dla interfejsu API sieci Web.
+Platforma ASP.NET Core 2.1 dodaje nowe konwencje programowania, które ułatwiają tworzenie czystych i bardziej opisowych interfejsów API sieci Web. Dodano nowy typ `ActionResult<T>`, aby zwracać albo typ odpowiedzi albo inny wynik akcji (podobnie jak w przypadku IActionResult), ale nadal wskazywać typ odpowiedzi. Atrybut `[ApiController]` został również dodany jako sposób korzystania z konwencji i zachowań specyficznych dla interfejsu API sieci Web.
 
 Aby uzyskać więcej informacji, zobacz [Tworzenie interfejsów API sieci Web za pomocą programu ASP.NET Core](xref:web-api/index).
 
 ## <a name="ihttpclientfactory"></a>IHttpClientFactory
 
-Platforma ASP.NET Core 2.1 zawiera nową usługę `IHttpClientFactory`, która ułatwia konfigurowanie i używanie wystąpienia `HttpClient` w aplikacjach. `HttpClient` ma już pojęcie delegowania obsługi, które można połączyć ze sobą dla wychodzących żądań HTTP. Fabryka:
+Platforma ASP.NET Core 2.1 zawiera nową usługę `IHttpClientFactory`, która ułatwia konfigurowanie i używanie wystąpień `HttpClient` w aplikacjach. Klasa `HttpClient` ma już pojęcie delegowania programów obsługi, które można połączyć ze sobą dla wychodzących żądań HTTP. Fabryka:
 
 * Sprawia, że rejestrowanie wystąpień `HttpClient` na klienta o nazwie bardziej intuicyjne.
 * Implementuje obsługi Polly, umożliwiająca Polly zasady służący do ponawiania, CircuitBreakers itp.
@@ -132,24 +132,24 @@ Aby uzyskać więcej informacji, zobacz [inicjowanie żądań HTTP](xref:fundame
 
 ## <a name="kestrel-transport-configuration"></a>Konfiguracja transportu Kestrel
 
-W wersji platformy ASP.NET Core 2.1 transport domyślny serwera Kestrel nie jest już oparty na Libuv, ale na zarządzanych gniazdach. Aby uzyskać więcej informacji, zobacz [implementacji serwera sieci web Kestrel: konfiguracja transportu](xref:fundamentals/servers/kestrel#transport-configuration).
+W wersji platformy ASP.NET Core 2.1 transport domyślny serwera Kestrel nie jest już oparty na bibliotece libuv, ale na zarządzanych gniazdach. Aby uzyskać więcej informacji, zobacz [Implementacja serwera sieci web Kestrel: konfiguracja transportu](xref:fundamentals/servers/kestrel#transport-configuration).
 
 ## <a name="generic-host-builder"></a>Ogólny konstruktor hosta
 
-Został wprowadzony ogólny konstruktora hosta (`HostBuilder`). Ten konstruktor może służyć do aplikacji, które nie przetwarzają żądania HTTP (Obsługa komunikatów, zadania w tle itp.).
+Został wprowadzony ogólny konstruktor hosta (`HostBuilder`). Ten konstruktor może służyć do aplikacji, które nie przetwarzają żądań HTTP (Obsługa komunikatów, zadania w tle itp.).
 
-Aby uzyskać więcej informacji, zobacz [host ogólny .NET](xref:fundamentals/host/generic-host).
+Aby uzyskać więcej informacji, zobacz [Host ogólny .NET](xref:fundamentals/host/generic-host).
 
 ## <a name="updated-spa-templates"></a>Zaktualizowane szablony SPA
 
-Szablony aplikacji jednostronicowej dla szablonów Angular, React i platformy React z kontenera Redux są aktualizowane, aby używać standardowych struktur projektów i systemów budowania dla każdej z platform.
+Szablony aplikacji jednostronicowej dla platform Angular, React i React z Redux zostały zaktualizowane, aby używać standardowych struktur projektów i systemów budowania dla każdej z platform.
 
-Szablon platformy Angular jest oparty na interfejs wiersza polecenia Angular, a szablony platformy React są oparte na `create-react-app`.
+Szablon platformy Angular jest oparty na interfejsie wiersza polecenia Angular, a szablony platformy React — na narzędziu`create-react-app`.
 Aby uzyskać więcej informacji, zobacz [używania szablonów aplikacji jednostronicowej platformy ASP.NET Core](xref:spa/index).
 
 ## <a name="razor-pages-search-for-razor-assets"></a>Wyszukiwanie zasobów Razor w stronach Razor
 
-W wersji 2.1 stron Razor wyszukiwanie zasobów Razor (na przykład układów i widoków częściowych), odbywa się w następujących katalogach w określonej kolejności:
+W wersji 2.1 w programie Razor Pages wyszukiwanie zasobów Razor (na przykład układów i widoków częściowych) odbywa się w następujących katalogach w podanej kolejności:
 
 1. Bieżący folder stron.
 1. */Pages/Shared/*
@@ -157,11 +157,11 @@ W wersji 2.1 stron Razor wyszukiwanie zasobów Razor (na przykład układów i w
 
 ## <a name="razor-pages-in-an-area"></a>Strony razor, w obszarze
 
-Obsługiwane są teraz strony Razor w [obszarach](xref:mvc/controllers/areas). Aby zobaczyć przykład wykorzystania obszarów, należy utworzyć nową aplikację sieci web dla stron Razor za uwierzytelnianiem za pomocą indywidualnych kont użytkowników. Aplikacja internetowa ze stronami Razor z uwierzytelnianiem za pomocą indywidualnych kont użytkowników zawiera */Areas/Identity/Pages*.
+Narzędzie Razor Pages obsługuje teraz [obszary](xref:mvc/controllers/areas). Aby zobaczyć przykład wykorzystania obszarów, należy utworzyć nową aplikację internetową Razor Pages z indywidualnymi kontami użytkowników. Aplikacja internetowa Razor Pages z indywidualnymi kontami użytkowników zawiera element */Areas/Identity/Pages*.
 
 ## <a name="mvc-compatibility-version"></a>Wersja zgodności MVC
 
-Metoda <xref:Microsoft.Extensions.DependencyInjection.MvcCoreMvcBuilderExtensions.SetCompatibilityVersion*> umożliwia aplikacji włączenie lub rezygnację z potencjalnych zmiany zachowania wprowadzonych w programie ASP.NET Core MVC 2.1 lub nowszej.
+Metoda <xref:Microsoft.Extensions.DependencyInjection.MvcCoreMvcBuilderExtensions.SetCompatibilityVersion*> umożliwia aplikacji włączenie wykorzystania lub rezygnację ze zmian zachowania wprowadzanych w programie ASP.NET Core MVC w wersji 2.1 lub nowszej, które potencjalnie mogą prowadzić do awarii.
 
 Aby uzyskać więcej informacji, zobacz <xref:mvc/compatibility-version>.
 

--- a/aspnetcore/release-notes/aspnetcore-2.1.md
+++ b/aspnetcore/release-notes/aspnetcore-2.1.md
@@ -1,5 +1,5 @@
 ---
-title: What's new in platformy ASP.NET Core 2.1
+title: Co nowego w programie ASP.NET Core 2.1
 author: isaac2004
 description: Dowiedz się więcej o nowych funkcjach w programie ASP.NET Core 2.1.
 monikerRange: = aspnetcore-2.1
@@ -14,79 +14,79 @@ ms.contentlocale: pl-PL
 ms.lasthandoff: 08/22/2018
 ms.locfileid: "41819475"
 ---
-# <a name="whats-new-in-aspnet-core-21"></a>What's new in platformy ASP.NET Core 2.1
+# <a name="whats-new-in-aspnet-core-21"></a>Co nowego w programie ASP.NET Core 2.1
 
-W tym artykule przedstawiono najbardziej znaczących zmian w programie ASP.NET Core 2.1 wraz z łączami do odpowiedniej dokumentacji.
+W tym artykule przedstawiono najbardziej znaczące zmiany w programie ASP.NET Core 2.1 wraz z łączami do odpowiedniej dokumentacji.
 
 ## <a name="signalr"></a>SignalR
 
-Ma został przepisany SignalR dla platformy ASP.NET Core 2.1. SignalR platformy ASP.NET Core zawiera szereg ulepszeń:
+SignalR został przepisany dla platformy ASP.NET Core 2.1. SignalR dla ASP.NET Core zawiera szereg ulepszeń:
 
-* Uproszczony model skalowalnego w poziomie.
-* Nowy klient JavaScript za pomocą niezależne jQuery.
-* Nowy compact binarne protokół oparte na MessagePack.
+* Uproszczony model skalowania w poziomie.
+* Nowy klient JavaScript bez zależności od jQuery.
+* Nowy kompaktowy protokół binarny oparty na MessagePack.
 * Informacje dotyczące obsługi niestandardowych protokołów.
 * Nowy model odpowiedzi przesyłania strumieniowego.
-* Obsługa klientów zgodnie z ustawieniami systemu od zera funkcja WebSockets.
+* Obsługa klientów opartych bezpośrednio na WebSockets.
 
 Aby uzyskać więcej informacji, zobacz [biblioteki SignalR platformy ASP.NET Core](xref:signalr/index).
 
-## <a name="razor-class-libraries"></a>Biblioteki klas razor
+## <a name="razor-class-libraries"></a>Biblioteki klas Razor
 
-ASP.NET Core 2.1 ułatwia tworzenie i obejmują interfejsu użytkownika opartego na Razor w bibliotece i udostępnić go w wielu projektach. Nowe umożliwia Razor SDK Kompilowanie plików Razor projekt biblioteki klas, które mogą być umieszczone w pakiet NuGet. Widoki stron w bibliotekach są automatycznie wykrywane i może być zastąpiona przez aplikację. Dzięki integracji kompilacji Razor do kompilacji:
+ASP.NET Core 2.1 ułatwia tworzenie i dołączanie interfejsu użytkownika opartego na Razor w bibliotece i udostępnianie go w wielu projektach. Nowe Razor SDK umożliwia kompilowanie plików Razor do bibliotek klas, które mogą być umieszczone w pakietach NuGet. Widoki stron w bibliotekach są automatycznie wykrywane i mogą być nadpisane w aplikacji. Dzięki integracji kompilacji Razor do kompilacji:
 
-* Czas uruchamiania aplikacji jest znacznie szybsze.
-* Szybkie aktualizacje widokami Razor i stron w czasie wykonywania są nadal dostępne jako część przepływu pracy iteracyjne projektowanie.
+* Czas uruchamiania aplikacji jest znacznie krótszy.
+* Szybkie aktualizacje widoków Razor i stron w czasie wykonywania są nadal dostępne jako część przepływu pracy iteracyjne projektowanie.
 
 Aby uzyskać więcej informacji, zobacz [tworzenia interfejsu użytkownika do wielokrotnego użytku, używając projektu biblioteki klas Razor](xref:razor-pages/ui-class).
 
 ## <a name="identity-ui-library--scaffolding"></a>Biblioteka interfejsów użytkownika tożsamości i tworzenia szkieletów
 
-Platforma ASP.NET Core 2.1 udostępnia [tożsamości platformy ASP.NET Core](xref:security/authentication/identity) jako [biblioteki klas Razor](xref:razor-pages/ui-class). Aplikacje, które zawierają tożsamości można zastosować nowy generator szkieletu tożsamości, aby selektywnie Dodawanie kodu źródłowego, znajdujących się w bibliotece klas Razor tożsamości (RCL). Można wygenerować kod źródłowy, aby można było zmodyfikować kod i zmienić zachowanie. Na przykład można nakazać Generator szkieletu do generowania kodu, używane podczas rejestracji. Wygenerowany kod mają pierwszeństwo przed ten sam kod w RCL tożsamości.
+Platforma ASP.NET Core 2.1 udostępnia mechanizm [tożsamości platformy ASP.NET Core](xref:security/authentication/identity) jako [bibliotekę klas Razor](xref:razor-pages/ui-class). Aplikacje, które używają mechanizmu tożsamości mogą zastosować nowy generator szkieletu tożsamości, aby wybiórczo wykorzystać kod źródłowy, znajdujący się w bibliotece klas Razor tożsamości (RCL). Można wygenerować kod źródłowy, aby można było zmodyfikować kod i zmienić zachowanie. Na przykład można nakazać Generatorowi szkieletu wygenerowanie kodu używanego podczas rejestracji. Wygenerowany kod ma pierwszeństwo przed ten sam kod w RCL tożsamości.
 
-Aplikacje, które wykonują **nie** obejmują uwierzytelniania można zastosować Generator szkieletu tożsamości, aby dodać pakiet RCL tożsamości. Masz możliwość wyboru tożsamości kodu do wygenerowania.
+Aplikacje, które **nie** obejmują uwierzytelniania mogą zastosować Generator szkieletu tożsamości, aby dodać pakiet RCL tożsamości. Masz możliwość wyboru kodu do wygenerowania.
 
 Aby uzyskać więcej informacji, zobacz [szkieletu tożsamość w projektach programu ASP.NET Core](xref:security/authentication/scaffold-identity).
 
 ## <a name="https"></a>HTTPS
 
-Za pomocą lepiej skoncentrować się na zabezpieczeniach i prywatności ważne jest włączenie protokołu HTTPS dla aplikacji sieci web. Wymuszanie protokołu HTTPS staje się coraz bardziej rygorystyczne w sieci web. Lokacje, które nie używają protokołu HTTPS, są uważane za niebezpieczne. Przeglądarki (przeglądarki Chromium, Mozilla) coraz częściej wymuszania, że funkcje sieci web musi być używany z bezpiecznym kontekście. [RODO](xref:security/gdpr) wymaga użycia protokołu HTTPS, aby chronić prywatność użytkowników. Przy użyciu protokołu HTTPS w środowisku produkcyjnym jest krytyczna, przy użyciu protokołu HTTPS w rozwoju może zapobiec problemom we wdrożeniu (na przykład niezabezpieczone łącza). Platforma ASP.NET Core 2.1 zawiera szereg ulepszeń, które ułatwiają do używania protokołu HTTPS podczas tworzenia i konfigurowania protokołu HTTPS w środowisku produkcyjnym. Aby uzyskać więcej informacji, zobacz [Wymuszanie protokołu HTTPS](xref:security/enforcing-ssl).
+Aby lepiej skoncentrować się na zabezpieczeniach i prywatności ważne jest włączenie protokołu HTTPS dla aplikacji sieci Web. Wymuszanie protokołu HTTPS staje się coraz bardziej rygorystyczne w sieci Web. Lokacje, które nie używają protokołu HTTPS, są uważane za niebezpieczne. Przeglądarki (Chromium, Mozilla) coraz częściej wymuszają, aby funkcje sieci Web powinny być używane w bezpiecznym kontekście. [RODO](xref:security/gdpr) wymaga użycia protokołu HTTPS, aby chronić prywatność użytkowników. Użycie protokołu HTTPS w środowisku produkcyjnym jest krytyczne, natomiast w środowisku rozwojowym może zapobiec problemom we wdrożeniu (na przykład niezabezpieczone łącza). Platforma ASP.NET Core 2.1 zawiera szereg ulepszeń, które ułatwiają wykorzystanie protokołu HTTPS podczas tworzenia i konfigurowania protokołu HTTPS w środowisku produkcyjnym. Aby uzyskać więcej informacji, zobacz [Wymuszanie protokołu HTTPS](xref:security/enforcing-ssl).
 
-### <a name="on-by-default"></a>Na domyślnie
+### <a name="on-by-default"></a>Włączony domyślnie
 
-W celu ułatwienia tworzenia bezpiecznej witryny sieci Web, HTTPS jest teraz włączony domyślnie. Począwszy od 2.1 Kestrel nasłuchuje na `https://localhost:5001` kiedy certyfikat rozwoju lokalnego znajduje się. Utworzono certyfikatu deweloperskiego:
+W celu ułatwienia tworzenia bezpiecznej witryny sieci Web, HTTPS jest teraz włączony domyślnie. Począwszy od 2.1 Kestrel nasłuchuje na `https://localhost:5001` kiedy certyfikat deweloperski jest obecny. Utworzenie certyfikatu deweloperskiego:
 
 * Jako część zestawu .NET Core SDK pierwszego uruchomienia komputera, gdy używasz zestawu SDK po raz pierwszy.
-* Ręcznie przy użyciu nowego `dev-certs` narzędzia.
+* Ręcznie przy użyciu nowego narzędzia `dev-certs`.
 
-Uruchom `dotnet dev-certs https --trust` ufać certyfikatowi.
+Uruchom `dotnet dev-certs https --trust`, aby zaufać certyfikatowi.
 
-### <a name="https-redirection-and-enforcement"></a>Przekierowania protokołu HTTPS i wymuszania
+### <a name="https-redirection-and-enforcement"></a>Przekierowania protokołu HTTPS i wymuszenia
 
-Aplikacje internetowe zazwyczaj konieczne nasłuchiwania protokołów HTTP i HTTPS, ale następnie przekierowania całego ruchu HTTP na HTTPS. 2.1 wyspecjalizowanych pośredniczącym przekierowania protokołu HTTPS, inteligentnie przekierowującego na podstawie obecności konfiguracji lub powiązanych portów zostały wprowadzone.
+Aplikacje internetowe zazwyczaj wymagają nasłuchiwania protokołów HTTP i HTTPS, ale następnie przekierowania całego ruchu HTTP na HTTPS. W wersji 2.1 zostało wprowadzone wyspecjalizowane oprogramowanie pośredniczące przekierowania protokołu HTTPS, inteligentnie przekierowujące na podstawie obecności konfiguracji lub powiązanych portów.
 
-Korzystanie z protokołu HTTPS można dodatkowo wymuszane, za pomocą [interfejsów HTTP Strict transportu zabezpieczeń protokołu (HSTS)](xref:security/enforcing-ssl#http-strict-transport-security-protocol-hsts). HSTS powoduje, że przeglądarek zawsze dostęp do witryny za pośrednictwem protokołu HTTPS. Platforma ASP.NET Core 2.1 dodaje oprogramowanie pośredniczące HSTS, który obsługuje opcje dla maksymalnego wieku, poddomen, i HSTS wstępnego ładowania listy.
+Korzystanie z protokołu HTTPS można dodatkowo wymuszane, za pomocą [interfejsów HTTP Strict Transport Security (HSTS)](xref:security/enforcing-ssl#http-strict-transport-security-protocol-hsts). HSTS powoduje, że przeglądarka zawsze uzyskuje dostęp do witryny za pośrednictwem protokołu HTTPS. Platforma ASP.NET Core 2.1 dodaje oprogramowanie pośredniczące HSTS, który obsługuje opcje dla maksymalnego wieku, poddomen, i listy wstępnego ładowania HSTS.
 
 ### <a name="configuration-for-production"></a>Konfiguracja dla trybu produkcyjnego
 
-W środowisku produkcyjnym należy jawnie skonfigurować protokół HTTPS. 2.1 domyślny schemat konfiguracji dotyczące konfigurowania protokołu HTTPS dla Kestrel został dodany. Aplikacje można skonfigurować do użycia:
+W środowisku produkcyjnym należy jawnie skonfigurować protokół HTTPS. W wersji 2.1 został dodany domyślny schemat konfiguracji dotyczący konfigurowania protokołu HTTPS dla serwera Kestrel. Aplikacje można skonfigurować do użycia:
 
-* Wiele punktów końcowych, w tym adresy URL. Aby uzyskać więcej informacji, zobacz [implementacji serwera sieci web Kestrel: Konfiguracja punktu końcowego](xref:fundamentals/servers/kestrel#endpoint-configuration).
-* Certyfikat używany do obsługi protokołu HTTPS z plikiem na dysku lub z magazynu certyfikatów.
+* Wielu punktów końcowych, w tym adresów URL. Aby uzyskać więcej informacji, zobacz [implementacji serwera sieci web Kestrel: Konfiguracja punktu końcowego](xref:fundamentals/servers/kestrel#endpoint-configuration).
+* Certyfikatu używanego do obsługi protokołu HTTPS z pliku na dysku lub z magazynu certyfikatów.
 
 ## <a name="gdpr"></a>RODO
 
-Platformy ASP.NET Core udostępnia interfejsów API i szablony, które ułatwiają korzystanie z niektórych [Unii Europejskiej ogólnego danych (GDPR Protection Regulation)](https://www.eugdpr.org/) wymagania. Aby uzyskać więcej informacji, zobacz [RODO obsługi w programie ASP.NET Core](xref:security/gdpr). A [przykładową aplikację](https://github.com/aspnet/Docs/tree/live/aspnetcore/security/gdpr/sample) pokazano, jak i umożliwia testowanie większość punkty rozszerzenia RODO i interfejsów API dodano szablony platformy ASP.NET Core 2.1.
+Platforma ASP.NET Core udostępnia interfejsy API i szablony, które ułatwiają korzystanie z niektórych wymagań [Ogólne rozporządzenie o ochronie danych (GDPR, RODO)](https://www.eugdpr.org/). Aby uzyskać więcej informacji, zobacz [RODO w programie ASP.NET Core](xref:security/gdpr). A w [przykładowej aplikacji](https://github.com/aspnet/Docs/tree/live/aspnetcore/security/gdpr/sample) pokazano, jak i umożliwia testowanie, większość punktów rozszerzenia RODO i interfejsów API, które dodano w szablonach ASP.NET Core 2.1.
 
-## <a name="integration-tests"></a>Testy integracji
+## <a name="integration-tests"></a>Testy integracyjne
 
-Nowy pakiet został wprowadzony przetestować upraszczają tworzenie i wykonywanie. [Microsoft.AspNetCore.Mvc.Testing](https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc.Testing/) pakietu obsługuje następujące zadania:
+Został wprowadzony nowy pakiet upraszczający tworzenie i wykonywanie testów. [Microsoft.AspNetCore.Mvc.Testing](https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc.Testing/) obsługuje następujące zadania:
 
 * Kopiuje plik zależności (*\*.deps*) z przetestowanej aplikacji w projekcie testowym *bin* folderu.
-* Ustawia zawartości głównego katalogu głównego projektu przetestowanej aplikacji tak, aby pliki statyczne i stron/widoki są dostępne, gdy testy są wykonywane.
-* Udostępnia [WebApplicationFactory](/dotnet/api/microsoft.aspnetcore.mvc.testing.webapplicationfactory-1) klasy, aby usprawnić uruchamianie przetestowanej aplikacji za pomocą [elementu TestServer](/dotnet/api/microsoft.aspnetcore.testhost.testserver).
+* Ustawia zawartość głównego katalogu głównego projektu przetestowanej aplikacji tak, aby pliki statyczne i stron/widoki są dostępne, gdy testy są wykonywane.
+* Udostępnia klasę [WebApplicationFactory](/dotnet/api/microsoft.aspnetcore.mvc.testing.webapplicationfactory-1), aby usprawnić uruchamianie przetestowanej aplikacji za pomocą [elementu TestServer](/dotnet/api/microsoft.aspnetcore.testhost.testserver).
 
-Następującego testu używa [xUnit](https://xunit.github.io/) do sprawdzenia, czy strony indeksu ładuje z pomyślny kod statusu i poprawny nagłówek Content-Type:
+Następujący test używa [xUnit](https://xunit.github.io/) do sprawdzenia, czy strona indeksu ładuje się z pomyślnym kodem statusu i poprawny nagłówkiem Content-Type:
 
 ```csharp
 public class BasicTests
@@ -115,57 +115,57 @@ public class BasicTests
 
 Aby uzyskać więcej informacji, zobacz [testy integracji](xref:test/integration-tests) tematu.
 
-## <a name="apicontroller-actionresultt"></a>[Klasy ApiController], ActionResult\<T >
+## <a name="apicontroller-actionresultt"></a>[ApiController], ActionResult\<T>
 
-Platforma ASP.NET Core 2.1 dodaje nowe konwencje programowania, które ułatwiają tworzenie czyste i opisu interfejsów API sieci web. `ActionResult<T>` Nowy typ dodano na aplikację, aby zwracać typ odpowiedzi lub inny wynik akcji, (podobnie jak IActionResult), nadal wskazujące typ odpowiedzi. `[ApiController]` Atrybut został również dodany jako sposób korzystania z Konwencji specyficzne dla interfejsu API sieci Web i zachowania.
+Platforma ASP.NET Core 2.1 dodaje nowe konwencje programowania, które ułatwiają tworzenie czystych i bardziej opisowych interfejsów API sieci Web. Dodano nowy typ `ActionResult<T>`, aby zwracać albo typ odpowiedzi albo inny wynik akcji (podobnie jak IActionResult), ale nadal wskazując typ odpowiedzi. Atrybut `[ApiController]` został również dodany jako sposób korzystania z konwencji i zachowań specyficznych dla interfejsu API sieci Web.
 
 Aby uzyskać więcej informacji, zobacz [Tworzenie interfejsów API sieci Web za pomocą programu ASP.NET Core](xref:web-api/index).
 
 ## <a name="ihttpclientfactory"></a>IHttpClientFactory
 
-Platforma ASP.NET Core 2.1 zawiera nową `IHttpClientFactory` usługa, która ułatwia konfigurowanie i używanie wystąpienia `HttpClient` w aplikacjach. `HttpClient` ma już pojęcie Delegowanie obsługi, które można połączyć ze sobą dla wychodzących żądań HTTP. Fabryka:
+Platforma ASP.NET Core 2.1 zawiera nową usługę `IHttpClientFactory`, która ułatwia konfigurowanie i używanie wystąpienia `HttpClient` w aplikacjach. `HttpClient` ma już pojęcie delegowania obsługi, które można połączyć ze sobą dla wychodzących żądań HTTP. Fabryka:
 
 * Sprawia, że rejestrowanie wystąpień `HttpClient` na klienta o nazwie bardziej intuicyjne.
 * Implementuje obsługi Polly, umożliwiająca Polly zasady służący do ponawiania, CircuitBreakers itp.
 
 Aby uzyskać więcej informacji, zobacz [inicjowanie żądań HTTP](xref:fundamentals/http-requests).
 
-## <a name="kestrel-transport-configuration"></a>Konfiguracja transportu kestrel
+## <a name="kestrel-transport-configuration"></a>Konfiguracja transportu Kestrel
 
-W wersji platformy ASP.NET Core 2.1 firmy Kestrel transportu domyślnego jest już oparte na Libuv, ale oparta na zarządzanych gniazda. Aby uzyskać więcej informacji, zobacz [implementacji serwera sieci web Kestrel: konfiguracja transportu](xref:fundamentals/servers/kestrel#transport-configuration).
+W wersji platformy ASP.NET Core 2.1 transport domyślny serwera Kestrel nie jest już oparty na Libuv, ale na zarządzanych gniazdach. Aby uzyskać więcej informacji, zobacz [implementacji serwera sieci web Kestrel: konfiguracja transportu](xref:fundamentals/servers/kestrel#transport-configuration).
 
-## <a name="generic-host-builder"></a>Konstruktor ogólnego hosta
+## <a name="generic-host-builder"></a>Ogólny konstruktor hosta
 
-Ogólny konstruktora hosta (`HostBuilder`) została wprowadzona. Ten konstruktor może służyć do aplikacji, które nie przetwarzają żądania HTTP (Obsługa komunikatów, zadania w tle itp.).
+Został wprowadzony ogólny konstruktora hosta (`HostBuilder`). Ten konstruktor może służyć do aplikacji, które nie przetwarzają żądania HTTP (Obsługa komunikatów, zadania w tle itp.).
 
-Aby uzyskać więcej informacji, zobacz [hosta ogólnego .NET](xref:fundamentals/host/generic-host).
+Aby uzyskać więcej informacji, zobacz [host ogólny .NET](xref:fundamentals/host/generic-host).
 
 ## <a name="updated-spa-templates"></a>Zaktualizowane szablony SPA
 
-Szablony aplikacji jednostronicowej dla szablonów Angular, React i platformy React z kontenera Redux są aktualizowane, aby używać struktur standardowy projekt i tworzenie systemów dla każdej struktury.
+Szablony aplikacji jednostronicowej dla szablonów Angular, React i platformy React z kontenera Redux są aktualizowane, aby używać standardowych struktur projektów i systemów budowania dla każdej z platform.
 
-Platformy Angular szablon jest oparty na interfejs wiersza polecenia usługi Angular i szablony platformy React są oparte na tworzenie platformy react aplikacji.
+Szablon platformy Angular jest oparty na interfejs wiersza polecenia Angular, a szablony platformy React są oparte na `create-react-app`.
 Aby uzyskać więcej informacji, zobacz [używania szablonów aplikacji jednostronicowej platformy ASP.NET Core](xref:spa/index).
 
-## <a name="razor-pages-search-for-razor-assets"></a>Strony razor wyszukiwania zasobów Razor
+## <a name="razor-pages-search-for-razor-assets"></a>Wyszukiwanie zasobów Razor w stronach Razor
 
-2.1 stron Razor Wyszukaj Razor zasoby (na przykład układy i częściowych), w następujących katalogach w określonej kolejności:
+W wersji 2.1 stron Razor wyszukiwanie zasobów Razor (na przykład układów i widoków częściowych), odbywa się w następujących katalogach w określonej kolejności:
 
 1. Bieżący folder stron.
-1. */Pages/udostępnione /*
-1. */Views/udostępnione /*
+1. */Pages/Shared/*
+1. */Views/Shared /*
 
 ## <a name="razor-pages-in-an-area"></a>Strony razor, w obszarze
 
-Obsługują teraz stron razor [obszarów](xref:mvc/controllers/areas). Aby zobaczyć przykład obszarów, należy utworzyć nową aplikację sieci web dla stron Razor za pomocą indywidualnych kont użytkowników. Aplikacja internetowa ze stronami Razor za pomocą indywidualnych kont użytkowników zawiera */Areas/Identity/Pages*.
+Obsługiwane są teraz strony Razor w [obszarach](xref:mvc/controllers/areas). Aby zobaczyć przykład wykorzystania obszarów, należy utworzyć nową aplikację sieci web dla stron Razor za uwierzytelnianiem za pomocą indywidualnych kont użytkowników. Aplikacja internetowa ze stronami Razor z uwierzytelnianiem za pomocą indywidualnych kont użytkowników zawiera */Areas/Identity/Pages*.
 
 ## <a name="mvc-compatibility-version"></a>Wersja zgodności MVC
 
-<xref:Microsoft.Extensions.DependencyInjection.MvcCoreMvcBuilderExtensions.SetCompatibilityVersion*> Metody umożliwia aplikacji opcjonalnych lub zrezygnować z potencjalnie przełomowe zmiany zachowania wprowadzonych w programie ASP.NET Core MVC 2.1 lub nowszej.
+Metoda <xref:Microsoft.Extensions.DependencyInjection.MvcCoreMvcBuilderExtensions.SetCompatibilityVersion*> umożliwia aplikacji włączenie lub rezygnację z potencjalnych zmiany zachowania wprowadzonych w programie ASP.NET Core MVC 2.1 lub nowszej.
 
 Aby uzyskać więcej informacji, zobacz <xref:mvc/compatibility-version>.
 
-## <a name="migrate-from-20-to-21"></a>Migrowanie z wersji 2.0 do wersji 2.1
+## <a name="migrate-from-20-to-21"></a>Migracja z wersji 2.0 do wersji 2.1
 
 Zobacz [migracji z programu ASP.NET Core 2.0 i 2.1](xref:migration/20_21).
 


### PR DESCRIPTION
Machine translation, especially in the getting-started page and release notes for 2.1, was very poor, sometimes even not translating incorrectly (e.g. leaving out "no"). Fixed it a bit.